### PR TITLE
Allow small screens to reach accept button

### DIFF
--- a/gdpr.js
+++ b/gdpr.js
@@ -547,6 +547,7 @@
                 "box-shadow: 0 0 0.1rem 0 rgba(0, 0, 0, 0.3);" +
                 "z-index: 10001;" +
                 "font-size: 1em;" +
+                "overflow: auto" +
                 "}" +
                 "" +
                 "#gdpr_modal #gdpr_modal_titel {" +


### PR DESCRIPTION
On mobile screens it is not possible to reach the 'accept' button, which prevents me from reaching te true application.
This should fix it with the most minimal code.